### PR TITLE
Update to allow protocol in address being tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ docker run --rm -it azch/loadtest <public ip of order capture service>
 
 To run this using Azure Container Instances
 ```sh
-az container create -g akschallenge --n loadtest --image azch/loadtest -e SERVICE_IP=<public ip of order capture service> --restart-policy Never --no-wait
+az container create -g akschallenge --n loadtest --image azch/loadtest -e SERVICE_ENDPOINT=http://<public ip of order capture service> --restart-policy Never --no-wait
 
 az container attach -g akschallenge --n loadtest
 
@@ -14,7 +14,7 @@ az container delete -g akschallenge --n loadtest
 ```
 
 ```sh
-az container create -g akschallenge --name loadtest --image azch/loadtest  --restart-policy Never  --no-wait --environment-variables SERVICE_IP=23.96.91.35
+az container create -g akschallenge --name loadtest --image azch/loadtest  --restart-policy Never  --no-wait --environment-variables SERVICE_ENDPOINT=http://23.96.91.35
 ```
 
 ```sh

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -6,15 +6,15 @@ echo "**************************************************************************
 
 if [ -z "$1" ]
 then
-  echo "No SERVICE_IP was passed as a parameter, assuming it is passed as environment variable"
+  echo "No SERVICE_ENDPOINT was passed as a parameter, assuming it is passed as environment variable"
 else
-  echo "SERVICE_IP was passed as a parameter"
-  export SERVICE_IP=$1
+  echo "SERVICE_ENDPOINT was passed as a parameter"
+  export SERVICE_ENDPOINT=$1
 fi
 
 export CONTENT_TYPE="Content-Type: application/json"
 export PAYLOAD='{"EmailAddress": "email@domain.com", "Product": "prod-1", "Total": 100}'
-export ENDPOINT=http://$SERVICE_IP/v1/order
+export ENDPOINT=$SERVICE_ENDPOINT/v1/order
 
 echo "POST $ENDPOINT"
 echo $CONTENT_TYPE


### PR DESCRIPTION
This PR switches from `SERVICE_IP` to `SERVICE_ENDPOINT` which should include the protocol prefix

The in the current script, the endpoint passed in as an IP and the URL constructed and passed to `hey` is hard coded to use HTTP. This prevents you using it once you have TLS/HTTPS enabled your service


